### PR TITLE
Update PKGBUILD

### DIFF
--- a/mingw-w64-arpack/0002-cmake-set-SUFFIX64.patch
+++ b/mingw-w64-arpack/0002-cmake-set-SUFFIX64.patch
@@ -1,13 +1,12 @@
 diff -urN arpack-ng-3.8.0_orig/CMakeLists.txt arpack-ng-3.8.0/CMakeLists.txt
 --- arpack-ng-3.8.0_orig/CMakeLists.txt	2020-12-07 11:40:45.000000000 +0100
 +++ arpack-ng-3.8.0/CMakeLists.txt	2021-12-09 09:55:07.736791800 +0100
-@@ -709,6 +709,10 @@
+@@ -709,6 +709,9 @@
  configure_file(PARPACK/SRC/MPI/parpack.pc.in "${PROJECT_BINARY_DIR}/PARPACK/SRC/MPI/parpack${LIBSUFFIX}.pc" @ONLY)
  configure_file(EXAMPLES/MATRIX_MARKET/arpackSolver.pc.in "${PROJECT_BINARY_DIR}/EXAMPLES/MATRIX_MARKET/arpackSolver.pc" @ONLY)
  
 +if (INTERFACE64)
 +  set(SUFFIX64 64)
-+  set(SUFFIX64_UNDERSCORE _64)
 +endif()
  
  install(TARGETS arpack

--- a/mingw-w64-arpack/PKGBUILD
+++ b/mingw-w64-arpack/PKGBUILD
@@ -1,5 +1,5 @@
 # $Id$
-# Maintainer (ArchLinux): Alexander Rodseth <rodseth@gmail.com>
+# Maintainer (ArchLinux): Alexander Rødseth <rodseth@gmail.com>
 # Contributor (ArchLinux): William Rea <sillywilly@gmail.com>
 # Contributor (ArchLinux): Stefan Husmann <stefan-husmann@t-online.de>
 # Maintainer (MSYS2): Ray Donnelly <mingw.android@gmail.com>
@@ -15,12 +15,12 @@ mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
 pkgdesc="Fortran77 subroutines designed to solve large scale eigenvalue problems (mingw-w64)"
 url='https://forge.scilab.org/index.php/p/arpack-ng/'
 license=('BSD')
-depends=($([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
          "${MINGW_PACKAGE_PREFIX}-openblas")
 if [ "$CARCH" = "x86_64" ]; then
 	depends+=("${MINGW_PACKAGE_PREFIX}-openblas64")
 fi
-makedepends=($([[ ${MINGW_PACKAGE_PREFIX} == *-clang-* ]] || echo "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-ng")
@@ -30,7 +30,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/opencollab/arpack-ng/a
 	"0002-cmake-set-SUFFIX64.patch")
 sha256sums=('ADA5AEB3878874383307239C9235B716A8A170C6D096A6625BFD529844DF003D'
             '94b215a281f115bd91e3370487bcfc97a1100aff82196d226927f7e395dc4cff'
-	    'CF1683E8388478CEBC6755420D940CFB999FE9BB99506DA1D8EAA9A58C8CE441')
+	    '778CDECFAFFA89F467DE2D652069C87E0463865B9BD33A3B85CE8C114A4C570D')
 
 prepare() {
   cd "${srcdir}/${_realname}-ng-${pkgver}"


### PR DESCRIPTION
`$([[ ${CARCH} == x86_64 ]] || echo "${MINGW_PACKAGE_PREFIX}-openblas64")`, this syntax won't work, the package won't build (I do not know why).